### PR TITLE
Counter-play to group notifications

### DIFF
--- a/src/com/untamedears/JukeAlert/listener/JukeAlertListener.java
+++ b/src/com/untamedears/JukeAlert/listener/JukeAlertListener.java
@@ -1,18 +1,30 @@
 package com.untamedears.JukeAlert.listener;
 
+import com.untamedears.JukeAlert.JukeAlert;
+import com.untamedears.JukeAlert.external.VanishNoPacket;
+import com.untamedears.JukeAlert.manager.PlayerManager;
+import com.untamedears.JukeAlert.manager.SnitchManager;
+import com.untamedears.JukeAlert.model.Snitch;
 import static com.untamedears.JukeAlert.util.Utility.doesSnitchExist;
 import static com.untamedears.JukeAlert.util.Utility.isDebugging;
 import static com.untamedears.JukeAlert.util.Utility.isOnSnitch;
 import static com.untamedears.JukeAlert.util.Utility.isPartialOwnerOfSnitch;
 import static com.untamedears.JukeAlert.util.Utility.notifyGroup;
-
+import com.untamedears.citadel.SecurityLevel;
+import com.untamedears.citadel.Utility;
+import com.untamedears.citadel.access.AccessDelegate;
+import com.untamedears.citadel.entity.Faction;
+import com.untamedears.citadel.entity.IReinforcement;
+import com.untamedears.citadel.entity.PlayerReinforcement;
+import com.untamedears.citadel.events.CreateReinforcementEvent;
+import com.untamedears.citadel.events.GroupChangeEvent;
+import com.untamedears.citadel.events.GroupChangeType;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
-
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -39,21 +51,8 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-
-import com.untamedears.JukeAlert.JukeAlert;
-import com.untamedears.JukeAlert.external.VanishNoPacket;
-import com.untamedears.JukeAlert.manager.PlayerManager;
-import com.untamedears.JukeAlert.manager.SnitchManager;
-import com.untamedears.JukeAlert.model.Snitch;
-import com.untamedears.citadel.SecurityLevel;
-import com.untamedears.citadel.Utility;
-import com.untamedears.citadel.access.AccessDelegate;
-import com.untamedears.citadel.entity.Faction;
-import com.untamedears.citadel.entity.IReinforcement;
-import com.untamedears.citadel.entity.PlayerReinforcement;
-import com.untamedears.citadel.events.CreateReinforcementEvent;
-import com.untamedears.citadel.events.GroupChangeEvent;
-import com.untamedears.citadel.events.GroupChangeType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 public class JukeAlertListener implements Listener {
 
@@ -61,7 +60,7 @@ public class JukeAlertListener implements Listener {
     SnitchManager snitchManager = plugin.getSnitchManager();
     PlayerManager playerManager = plugin.getPlayerManager();
     private final Map<UUID, Set<Snitch>> playersInSnitches = new TreeMap<UUID, Set<Snitch>>();
-	private final ArrayList<Location> previousLocations = new ArrayList<Location>();
+    private final ArrayList<Location> previousLocations = new ArrayList<Location>();
     private final VanishNoPacket vanishNoPacket = new VanishNoPacket();
 
     private boolean checkProximity(Snitch snitch, UUID accountId) {
@@ -73,69 +72,69 @@ public class JukeAlertListener implements Listener {
         return inList.contains(snitch);
     }
 
-	@EventHandler(priority = EventPriority.HIGHEST)
-	public void playerJoinEvent(PlayerJoinEvent event) {
-		Player player = event.getPlayer();
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void playerJoinEvent(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
         if (vanishNoPacket.isPlayerInvisible(player)) {
             return;
         }
-		UUID accountId = player.getUniqueId();
-		Set<Snitch> inList = new TreeSet<Snitch>();
-		playersInSnitches.put(accountId, inList);
+        UUID accountId = player.getUniqueId();
+        Set<Snitch> inList = new TreeSet<Snitch>();
+        playersInSnitches.put(accountId, inList);
 
-		Location location = player.getLocation();
-		World world = location.getWorld();
-		Set<Snitch> snitches = snitchManager.findSnitches(world, location);
-		for (Snitch snitch : snitches) {
-			if (!isOnSnitch(snitch, accountId)) {
+        Location location = player.getLocation();
+        World world = location.getWorld();
+        Set<Snitch> snitches = snitchManager.findSnitches(world, location);
+        for (Snitch snitch : snitches) {
+            if (!isOnSnitch(snitch, accountId)) {
                 snitch.imposeSnitchTax();
-				inList.add(snitch);
+                inList.add(snitch);
                 notifyGroup(
-                    snitch,
-                    ChatColor.AQUA + " * " + player.getDisplayName() + " logged in to snitch at " + snitch.getName()
-                    + " [" + snitch.getX() + " " + snitch.getY() + " " + snitch.getZ() + "]");
+                        snitch,
+                        ChatColor.AQUA + " * " + player.getDisplayName() + " logged in to snitch at " + snitch.getName()
+                        + " [" + snitch.getX() + " " + snitch.getY() + " " + snitch.getZ() + "]");
                 if (snitch.shouldLog()) {
                     plugin.getJaLogger().logSnitchLogin(snitch, location, player);
                 }
-			}
-		}
-	}
+            }
+        }
+    }
 
     public void handlePlayerExit(PlayerEvent event) {
-    	Player player = event.getPlayer();
-    	
+        Player player = event.getPlayer();
+
         if (vanishNoPacket.isPlayerInvisible(player)) {
             return;
         }
-		UUID accountId = player.getUniqueId();
-		playersInSnitches.remove(accountId);
+        UUID accountId = player.getUniqueId();
+        playersInSnitches.remove(accountId);
 
-		Location location = player.getLocation();
-		World world = location.getWorld();
-		Set<Snitch> snitches = snitchManager.findSnitches(world, location);
-		for (Snitch snitch : snitches) {
-			if (!isOnSnitch(snitch, accountId)) {
+        Location location = player.getLocation();
+        World world = location.getWorld();
+        Set<Snitch> snitches = snitchManager.findSnitches(world, location);
+        for (Snitch snitch : snitches) {
+            if (!isOnSnitch(snitch, accountId)) {
                 snitch.imposeSnitchTax();
                 notifyGroup(
-                    snitch,
-                    ChatColor.AQUA + " * " + player.getDisplayName() + " logged out in snitch at " + snitch.getName()
-                    + " [" + snitch.getX() + " " + snitch.getY() + " " + snitch.getZ() + "]");
+                        snitch,
+                        ChatColor.AQUA + " * " + player.getDisplayName() + " logged out in snitch at " + snitch.getName()
+                        + " [" + snitch.getX() + " " + snitch.getY() + " " + snitch.getZ() + "]");
                 if (snitch.shouldLog()) {
                     plugin.getJaLogger().logSnitchLogout(snitch, location, player);
                 }
-			}
-		}
+            }
+        }
     }
 
     @EventHandler(ignoreCancelled = true)
     public void playerKickEvent(PlayerKickEvent event) {
-		handlePlayerExit(event);
-	}
+        handlePlayerExit(event);
+    }
 
     @EventHandler(ignoreCancelled = true)
     public void playerQuitEvent(PlayerQuitEvent event) {
-		handlePlayerExit(event);
-	}
+        handlePlayerExit(event);
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void placeSnitchBlock(BlockPlaceEvent event) {
@@ -173,7 +172,7 @@ public class JukeAlertListener implements Listener {
                 Faction owner = reinforcement.getOwner();
                 if (owner == null) {
                     JukeAlert.getInstance().log(String.format(
-                        "No group on rein (%s): %s", reinforcement.getId(), reinforcement.getOwnerName()));
+                            "No group on rein (%s): %s", reinforcement.getId(), reinforcement.getOwnerName()));
                 }
                 if (reinforcement.getSecurityLevel().equals(SecurityLevel.GROUP)) {
                     Snitch snitch;
@@ -219,7 +218,7 @@ public class JukeAlertListener implements Listener {
                 Faction owner = reinforcement.getOwner();
                 if (owner == null) {
                     JukeAlert.getInstance().log(String.format(
-                        "No group on rein (%s): %s", reinforcement.getId(), reinforcement.getOwnerName()));
+                            "No group on rein (%s): %s", reinforcement.getId(), reinforcement.getOwnerName()));
                 }
                 if (reinforcement.getSecurityLevel().equals(SecurityLevel.GROUP)) {
                     Snitch snitch;
@@ -332,32 +331,33 @@ public class JukeAlertListener implements Listener {
         }
         Set<Snitch> snitches = snitchManager.findSnitches(world, location);
         for (Snitch snitch : snitches) {
-        	if (doesSnitchExist(snitch, true)) {
-        		
-        		if (isPartialOwnerOfSnitch(snitch, accountId)) {
-        			if (!inList.contains(snitch)) {
-	                	inList.add(snitch);
+            if (doesSnitchExist(snitch, true)) {
+
+                if (isPartialOwnerOfSnitch(snitch, accountId)) {
+                    if (!inList.contains(snitch)) {
+                        inList.add(snitch);
                         plugin.getJaLogger().logSnitchVisit(snitch);
-        			}
-        		}
-	            
-        		if ((!isOnSnitch(snitch, accountId) || isDebugging())) {
-	                if (!inList.contains(snitch)) {
-						snitch.imposeSnitchTax();
-	                	inList.add(snitch);
-						
-						notifyGroup(
-							snitch,
-							ChatColor.AQUA + " * " + player.getDisplayName() + " entered snitch at " + snitch.getName()
-							+ " [" + snitch.getX() + " " + snitch.getY() + " " + snitch.getZ() + "]");
-							
-	                    if (snitch.shouldLog()) {
-	                        plugin.getJaLogger().logSnitchEntry(snitch, location, player);
-	                    }
-	                }
-	            }
-        		
-        	}
+                    }
+                }
+
+                if ((!isOnSnitch(snitch, accountId) || isDebugging())) {
+                    if (!inList.contains(snitch)) {
+                        snitch.imposeSnitchTax();
+                        inList.add(snitch);
+                        if (!player.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
+
+                            notifyGroup(
+                                    snitch,
+                                    ChatColor.AQUA + " * " + player.getDisplayName() + " entered snitch at " + snitch.getName()
+                                    + " [" + snitch.getX() + " " + snitch.getY() + " " + snitch.getZ() + "]");
+                        }
+                        if (snitch.shouldLog()) {
+                            plugin.getJaLogger().logSnitchEntry(snitch, location, player);
+                        }
+                    }
+                }
+
+            }
         }
         snitches = snitchManager.findSnitches(world, location, true);
         Set<Snitch> rmList = new TreeSet<Snitch>();
@@ -387,20 +387,20 @@ public class JukeAlertListener implements Listener {
             DoubleChest chest = (DoubleChest) e.getInventory().getHolder();
             block = chest.getLocation().getBlock();
         } else {
-        	return;
+            return;
         }
         UUID accountId = player.getUniqueId();
-        	Set<Snitch> snitches = snitchManager.findSnitches(player.getWorld(), player.getLocation());
-        	for (Snitch snitch : snitches) {
-                if (!snitch.shouldLog()) {
-                    continue;
+        Set<Snitch> snitches = snitchManager.findSnitches(player.getWorld(), player.getLocation());
+        for (Snitch snitch : snitches) {
+            if (!snitch.shouldLog()) {
+                continue;
+            }
+            if (!isOnSnitch(snitch, accountId) || isDebugging()) {
+                if (checkProximity(snitch, accountId)) {
+                    plugin.getJaLogger().logUsed(snitch, player, block);
                 }
-        		if (!isOnSnitch(snitch, accountId) || isDebugging()) {
-        			if (checkProximity(snitch, accountId)) {
-        				plugin.getJaLogger().logUsed(snitch, player, block);
-        			}
-        		}
-        	}
+            }
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGH)


### PR DESCRIPTION
With the recent few patches / intended patches it has all been making defending easier.
Also, with Group notifications for entries having no Counter-play except waiting till everyone is offline, which is hard with massive snitch networks with dozens of people added to it, who all live in different time zones.

So, for some there is never a time where someone is not online to see the notification.

Here is something to help balance a bit, if the user has an invisibility potion active it will not notify the group about an entry, it still will notify for log-ins and log-outs. It will also still record it to the Database if it shouldLog.

I also fixed the inconsistency in the indentation. So it is going to say I change a lot more than I actually did, check on line: https://github.com/KillerSmurf/JukeAlert/compare/Civcraft:master...master#diff-4a1d427f499cb9ee50b9bb8aab9274b9R347
