### PR TITLE
Feature Addition:  Juke Lever Triggering

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,3 +11,4 @@ settings:
   logsPerPage: 10
   daysFromLastAdminVisitForLoggedSnitchCulling: 0
   daysFromLastAdminVisitForNonLoggedSnitchCulling: 0  
+  allowTriggeringLevers: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: JukeAlert
 main: com.untamedears.JukeAlert.JukeAlert
-version: 1.2.4
+version: 1.2.5
 depend: [Citadel]
 commands:
   ja:
@@ -36,6 +36,9 @@ commands:
     description: Run-time configuration
     usage: /jaconfig <option> <value> 
     permission: jukealert.admin.jaconfig
+  jatogglelevers:
+    description:  Sets flag that indicates if a juke should trigger a lever.
+    usage: /jatogglelevers <0|1>
 permissions:
   jukealert.admin.jagroup:
     description: Use /jagroup even when not the owner

--- a/src/com/untamedears/JukeAlert/JukeAlert.java
+++ b/src/com/untamedears/JukeAlert/JukeAlert.java
@@ -11,6 +11,7 @@ import com.untamedears.JukeAlert.command.commands.JaListCommand;
 import com.untamedears.JukeAlert.command.commands.JaMuteCommand;
 import com.untamedears.JukeAlert.command.commands.LookupCommand;
 import com.untamedears.JukeAlert.command.commands.NameCommand;
+import com.untamedears.JukeAlert.command.commands.JaToggleLeversCommand;
 import com.untamedears.JukeAlert.group.GroupMediator;
 import com.untamedears.JukeAlert.listener.JukeAlertListener;
 import com.untamedears.JukeAlert.manager.ConfigManager;
@@ -78,6 +79,7 @@ public class JukeAlert extends JavaPlugin {
         commandHandler.addCommand(new LookupCommand());
         commandHandler.addCommand(new JaMuteCommand());
         commandHandler.addCommand(new ConfigCommand());
+        commandHandler.addCommand(new JaToggleLeversCommand());
     }
 
     public static JukeAlert getInstance() {

--- a/src/com/untamedears/JukeAlert/command/commands/HelpCommand.java
+++ b/src/com/untamedears/JukeAlert/command/commands/HelpCommand.java
@@ -20,7 +20,7 @@ public class HelpCommand extends PlayerCommand {
 	public boolean execute(CommandSender sender, String[] args) {
 		if (sender instanceof Player){
 			Player player = (Player) sender;
-			player.sendMessage(ChatColor.AQUA+ "Commands are: \n jahelp: Gives you possible Commands. \n jainfo: Gives You information in the Snitch. \n jaclear: Clears the snitch. \n janame: Names the Snitch. \n jalist: Gives info for snitches you own. \n jamute: Adds or removes from juke alert ignore list.");
+			player.sendMessage(ChatColor.AQUA+ "Commands are: \n jahelp: Gives you possible Commands. \n jainfo: Gives You information in the Snitch. \n jaclear: Clears the snitch. \n janame: Names the Snitch. \n jalist: Gives info for snitches you own. \n jamute: Adds or removes from juke alert ignore list. \n JaToggleLevers: Sets the flag that indicates if jukes should trigger levers.");
 		}
 		
 		return true;

--- a/src/com/untamedears/JukeAlert/command/commands/JaToggleLeversCommand.java
+++ b/src/com/untamedears/JukeAlert/command/commands/JaToggleLeversCommand.java
@@ -1,0 +1,87 @@
+package com.untamedears.JukeAlert.command.commands;
+
+import static com.untamedears.JukeAlert.util.Utility.findTargetedOwnedSnitch;
+import static com.untamedears.JukeAlert.util.Utility.isPartialOwnerOfSnitch;
+
+import org.bukkit.ChatColor;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.untamedears.JukeAlert.JukeAlert;
+import com.untamedears.JukeAlert.command.PlayerCommand;
+import com.untamedears.JukeAlert.model.Snitch;
+
+public class JaToggleLeversCommand extends PlayerCommand {
+	 public JaToggleLeversCommand() {
+	        super("ToggleLevers");
+	        setDescription("Sets flag indicating if this juke will toggle levers on certain actions.");
+	        setUsage("/JaToggleLevers <1|0>");
+	        setArgumentRange(1, 1);
+	        setIdentifier("jatogglelevers");
+	    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+    	
+    	if (!JukeAlert.getInstance().getConfigManager().getAllowTriggeringLevers()) {
+            sender.sendMessage(ChatColor.RED + "JukeAlert - ToggleLevers feature disabled!");
+            return false;
+    	}
+    	
+        if (sender instanceof Player) {
+            Player player = (Player) sender;
+            World world = player.getWorld();
+
+            String name = "";
+            int flagValue;
+            Boolean flag;
+            try {
+            	flagValue = Integer.parseInt(args[0]);
+            	
+            	if (0 == flagValue)
+            		flag = false;
+            	else
+            		flag = true;
+            	
+            } catch (Exception e) {
+                sender.sendMessage(ChatColor.RED + "Invalid Usage - /JaToggleLevers 1 or /JaToggleLevers 0.");
+                return false;
+            }
+            
+            Snitch snitch = findTargetedOwnedSnitch(player);
+            
+            if (snitch != null) {
+            	
+            	if (!snitch.shouldLog())
+            	{
+                    sender.sendMessage(ChatColor.RED + "Toggle Lever Settings can only be applied to logging jukeboxes.");
+                    return false;
+            	}
+            	
+            	if (!isPartialOwnerOfSnitch(snitch, player.getUniqueId()))
+            	{
+                    sender.sendMessage(ChatColor.RED + "You do not own any snitches nearby!");
+                    return false;
+            	}
+            	
+            	plugin.getJaLogger().updateSnitchToggleLevers(snitch, flag);
+            	Snitch newSnitch = snitch;
+            	newSnitch.setShouldToggleLevers(flag);
+            	plugin.getSnitchManager().removeSnitch(snitch);
+            	plugin.getSnitchManager().addSnitch(newSnitch);
+            	sender.sendMessage(ChatColor.AQUA + " Changed toggle levers settings to " + (flag ? "True" : "False") + ".");
+
+                return true;
+                
+            } else {
+                sender.sendMessage(ChatColor.RED + "You do not own any snitches nearby!");
+                return false;
+            }
+            
+        } else {
+            sender.sendMessage(ChatColor.RED + "You do not own any snitches nearby!");
+            return false;
+        }
+    }
+}

--- a/src/com/untamedears/JukeAlert/manager/ConfigManager.java
+++ b/src/com/untamedears/JukeAlert/manager/ConfigManager.java
@@ -28,6 +28,7 @@ public class ConfigManager
 	private int daysFromLastAdminVisitForLoggedSnitchCulling;
 	private int daysFromLastAdminVisitForNonLoggedSnitchCulling;
 	private boolean snitchEntryCullingEnabled;
+	private boolean allowTriggeringLevers;
 	private int maxEntryCount;
 	private int minEntryLifetimeDays;
 	private int maxEntryLifetimeDays;
@@ -88,6 +89,7 @@ public class ConfigManager
         logsPerPage = loadInt("settings.logsPerPage");
 		daysFromLastAdminVisitForLoggedSnitchCulling = loadInt("settings.daysFromLastAdminVisitForLoggedSnitchCulling");
 		daysFromLastAdminVisitForNonLoggedSnitchCulling = loadInt("settings.daysFromLastAdminVisitForNonLoggedSnitchCulling");
+        allowTriggeringLevers = loadBoolean("settings.allowTriggeringLevers",false);
         setDebugging(loadBoolean("settings.debugging"));
         if (isSet("settings.max_alert_distance")) {
             maxAlertDistanceAll = loadDouble("settings.max_alert_distance");
@@ -270,6 +272,10 @@ public class ConfigManager
 	
 	public int getDaysFromLastAdminVisitForLoggedSnitchCulling() {
 		return daysFromLastAdminVisitForLoggedSnitchCulling;
+	}
+	
+	public Boolean getAllowTriggeringLevers() {
+		return allowTriggeringLevers;
 	}
 
 	public void setLogsPerPage(int logsPerPage) {

--- a/src/com/untamedears/JukeAlert/model/Snitch.java
+++ b/src/com/untamedears/JukeAlert/model/Snitch.java
@@ -17,12 +17,14 @@ public class Snitch implements QTBox, Comparable {
     private Location location;
     private Faction group;
     private boolean shouldLog;
+    private boolean shouldToggleLevers;
     private int minx, maxx, miny, maxy, minz, maxz, radius;
 
-    public Snitch(Location loc, Faction group, boolean shouldLog) {
+    public Snitch(Location loc, Faction group, boolean shouldLog, boolean shouldToggleLevers) {
         this.group = group;
         this.shouldLog = shouldLog;
         this.location = loc;
+        this.shouldToggleLevers = shouldToggleLevers;
         this.name = "";
         radius = 11;
         calculateDimensions();
@@ -158,6 +160,14 @@ public class Snitch implements QTBox, Comparable {
 
     public void setShouldLog(boolean shouldLog) {
         this.shouldLog = shouldLog;
+    }
+    
+    public boolean shouldToggleLevers() {
+    	return shouldToggleLevers;
+    }
+    
+    public void setShouldToggleLevers(boolean shouldToggleLevers) {
+    	this.shouldToggleLevers = shouldToggleLevers;
     }
 
     //Checks if the location is within the cuboid.


### PR DESCRIPTION
Included is new code to allow new feature "Juke Lever Triggering" to
exist.  Specifically, this code will allow jukeboxes (not noteblocks)
that have opted in to lever triggering to cause a lever to momentarily
fire (~0.75 second ish) such that cardinal north when a player
enters/logs in a snitch radius, cardinal south when a player opens a
chest, cardinal east when a player places a block, and cardinal west
when a player breaks a block.  This new feature is safeguarded by new
configuration setting (default false) "allowTriggeringLevers".  If
false, which it is by default, then there should be no server-affect of
this change except a new column added to the main snitches table.  If
true, then it will allow users (owners/moderators of a snitch) to call
new command /jaToggleLevers that will allow them to opt-in a juke box
into this new functionality.  It is possible to remove this
functionality after it has gone live by modifying the configuration
option with no harm caused.  While levers were chosen for this
functionality, it could easily have been buttons as they offer the same
benefit (redstone pulse) and are part of the bukkit supported mechanism
for said functionality - levers were kept simply because the client
visible affect looks more interesting and novel.   Churned plugin.yml
version.
