### PR TITLE
Lower the EventPriority of playerQuitEvent

### DIFF
--- a/src/com/untamedears/JukeAlert/listener/JukeAlertListener.java
+++ b/src/com/untamedears/JukeAlert/listener/JukeAlertListener.java
@@ -162,7 +162,7 @@ public class JukeAlertListener implements Listener {
         handlePlayerExit(event);
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void playerQuitEvent(PlayerQuitEvent event) {
         handlePlayerExit(event);
     }


### PR DESCRIPTION
Should fix https://github.com/Civcraft/JukeAlert/issues/42

The playerQuitEvent in VanishNoPacket was fired before the event in JukeAlert what caused vanished players to show up on snitches when they log out. 