### PR TITLE
Added filtering to /jainfo (issue #62)

### DIFF
--- a/src/main/java/com/untamedears/JukeAlert/command/commands/InfoCommand.java
+++ b/src/main/java/com/untamedears/JukeAlert/command/commands/InfoCommand.java
@@ -2,6 +2,7 @@ package com.untamedears.JukeAlert.command.commands;
 
 import static com.untamedears.JukeAlert.util.Utility.findLookingAtOrClosestSnitch;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -12,32 +13,62 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import vg.civcraft.mc.civmodcore.command.PlayerCommand;
-import vg.civcraft.mc.namelayer.permission.PermissionType;
-
 import com.untamedears.JukeAlert.JukeAlert;
+import com.untamedears.JukeAlert.model.LoggedAction;
 import com.untamedears.JukeAlert.model.Snitch;
 import com.untamedears.JukeAlert.tasks.GetSnitchInfoPlayerTask;
+
+import vg.civcraft.mc.civmodcore.command.PlayerCommand;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
 
 public class InfoCommand extends PlayerCommand {
 
     public class History {
-        public History(int snitchId, int page) {
+        public History(int snitchId, int page, LoggedAction filterAction, String filterPlayer) {
             this.snitchId = snitchId;
             this.page = page;
+            this.filterAction = filterAction;
+            this.filterPlayer = filterPlayer;
         }
         public int snitchId;
         public int page;
+        public LoggedAction filterAction;
+        public String filterPlayer;
     }
-
+    
     private static Map<UUID, History> playerPage_ = new TreeMap<UUID, History>();
+    private static final String[] autocompleteCommands = {"next", "censor", "action=", "player="};
 
     public InfoCommand() {
         super("Info");
         setDescription("Displays information from a Snitch");
-        setUsage("/jainfo <page number or 'next'> [censor]");
-        setArguments(0, 2);
+        setUsage("/jainfo [<page number> or 'next'] [censor] [action=<action type>] [player=<player name>]");
+        setArguments(0, 6); // Max args = 6 because the action might be split into two
         setIdentifier("jainfo");
+    }
+    
+    /**
+     * Attempts to match a string to one of the LoggedAction actions
+     * @param action - case insensitive
+     * @return The matching LoggedAction, or null if a matching action couldn't be found
+     */
+    private static LoggedAction decodeAction(String action){
+        // Strip quotes
+        if (action.startsWith("\"") && action.length() > 1){
+            action = action.substring(1);
+        }
+        if (action.endsWith("\"") && action.length() > 1){
+            action = action.substring(0,  action.length()-1);
+        }
+        action = action.toUpperCase();
+        for (LoggedAction a : LoggedAction.values()){
+            String actionName = a.toString().toUpperCase();
+            String actionDisp = a.toActionString().toUpperCase();
+            if (actionName.equals(action) || actionDisp.equals(action)){
+                return a;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -52,17 +83,88 @@ public class InfoCommand extends PlayerCommand {
             }
             final int snitchId = snitch.getId();
             int offset = 1;
+            LoggedAction filterAction = null;
+            String filterPlayer = "";
+            boolean censorFlag = false;
+            boolean nextFlag = false;
+            
             if (args.length > 0) {
-                try {
-                    offset = Integer.parseInt(args[0]);
-                } catch (NumberFormatException e) {
-                    if (playerPage_.containsKey(accountId)) {
-                        final History hist = playerPage_.get(accountId);
-                        if (hist != null && hist.snitchId == snitchId) {
-                            offset = hist.page + 1;
-                        } else {
-                            offset = 1;
+                
+                // Reassemble any arguments that are enclosed in quotes and were split
+                List<String> fixedArgs = new ArrayList<String>();
+                for (int pos=0; pos<args.length; pos++){
+                    String currArg = args[pos];
+                    if (currArg.contains("\"")){
+                        // Found the first quote. Scan ahead to assemble the rest of the argument (if there's another quote present)
+                        boolean secondQuotePresent = false;
+                        String joinedArg = currArg;
+                        int nextPos=pos+1;
+                        for (; nextPos<args.length; nextPos++){
+                            String nextArg = args[nextPos];
+                            if (nextArg.contains("\"")){
+                              secondQuotePresent = true;
+                              joinedArg += " " + nextArg;
+                              break;
+                          }
+                          else{
+                                joinedArg += " " + nextArg;
+                            }
                         }
+                        if (secondQuotePresent){
+                            fixedArgs.add(joinedArg);
+                            pos = nextPos;
+                        }
+                        else{
+                            fixedArgs.add(currArg);
+                        }
+                    }
+                    else{
+                        fixedArgs.add(currArg);
+                    }
+                }
+                
+                // Parse each argument
+                for (String arg : fixedArgs){
+                    arg = arg.toLowerCase().trim();
+                    if (arg.equals("next")){
+                        nextFlag = true;
+                        continue;
+                    }
+                    else if (arg.equals("censor")){
+                        censorFlag = true;
+                        continue;
+                    }
+                    else if (arg.startsWith("action=")){
+                        if (arg.length() > 7){
+                            filterAction = decodeAction(arg.substring(7));
+                            if (filterAction == null){
+                                sender.sendMessage(ChatColor.RED + "Couldn't parse action type '" + arg.substring(7) + "'");
+                                return false;
+                            }
+                            continue;
+                        }
+                    }
+                    else if (arg.startsWith("player=")){
+                        if (arg.length() > 7){
+                            filterPlayer = arg.substring(7);
+                            continue;
+                        }
+                    }
+                    else{
+                        try {
+                            offset = Integer.parseInt(arg);
+                            continue;
+                        } catch (NumberFormatException e) {}
+                    }
+                    
+                    sender.sendMessage(ChatColor.RED + "Unrecognized argument: '" + arg + "'");
+                    return false;
+                }
+
+                if (nextFlag && playerPage_.containsKey(accountId)) {
+                    final History hist = playerPage_.get(accountId);
+                    if (hist != null && hist.snitchId == snitchId && hist.filterAction == filterAction && hist.filterPlayer.equals(filterPlayer)) {
+                        offset = hist.page + 1;
                     } else {
                         offset = 1;
                     }
@@ -71,8 +173,8 @@ public class InfoCommand extends PlayerCommand {
             if (offset < 1) {
                 offset = 1;
             }
-            playerPage_.put(accountId, new History(snitchId, offset));
-            sendLog(sender, snitch, offset, args.length == 2);
+            playerPage_.put(accountId, new History(snitchId, offset, filterAction, filterPlayer));
+            sendLog(sender, snitch, offset, censorFlag, filterAction, filterPlayer);
             return true;
         } else {
             sender.sendMessage(ChatColor.RED + " You do not own any snitches nearby!");
@@ -80,16 +182,32 @@ public class InfoCommand extends PlayerCommand {
         }
     }
 
-    private void sendLog(CommandSender sender, Snitch snitch, int offset, boolean shouldCensor) {
+    private void sendLog(CommandSender sender, Snitch snitch, int offset, boolean shouldCensor, LoggedAction filterAction, String filterPlayer) {
         Player player = (Player) sender;
-        GetSnitchInfoPlayerTask task = new GetSnitchInfoPlayerTask(JukeAlert.getInstance(), snitch.getId(), snitch.getName(), offset, player, shouldCensor);
+        GetSnitchInfoPlayerTask task = new GetSnitchInfoPlayerTask(JukeAlert.getInstance(), snitch.getId(), snitch.getName(), offset, player, shouldCensor, filterAction, filterPlayer);
         Bukkit.getScheduler().runTaskAsynchronously(JukeAlert.getInstance(), task);
 
     }
 
-	@Override
-	public List<String> tabComplete(CommandSender sender, String[] args) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public List<String> tabComplete(CommandSender sender, String[] args) {
+        List<String> completedArgs = new ArrayList<String>();
+        if (args.length > 0){
+            // Copy all of the arguments except the last one to the output
+            for (int i=0; i<args.length-2; i++){
+                completedArgs.add(args[i]);
+            }
+            // Try to complete the last argument
+            String lastArg = args[args.length-1];
+            for (String command : autocompleteCommands){
+                if (command.startsWith(lastArg)){
+                    lastArg = command;
+                    break;
+                }
+            }
+            // Add the last argument to the output
+            completedArgs.add(lastArg);
+        }
+        return completedArgs;
+    }
 }

--- a/src/main/java/com/untamedears/JukeAlert/model/LoggedAction.java
+++ b/src/main/java/com/untamedears/JukeAlert/model/LoggedAction.java
@@ -1,5 +1,11 @@
 package com.untamedears.JukeAlert.model;
 
+import java.util.logging.Level;
+
+import org.bukkit.ChatColor;
+
+import com.untamedears.JukeAlert.JukeAlert;
+
 /**
  * Enum that represents a type of action that a snitch can record, and the value
  * that goes into the database for said action
@@ -57,6 +63,32 @@ public enum LoggedAction {
             case 14: return ENTITY_MOUNT;
             case 15: return ENTITY_DISMOUNT;
             default: return UNKNOWN;
+        }
+    }
+    
+    /**
+     * Returns the 'human-friendly' version of the action
+     * Currently this is only used when displaying snitch logs
+     * @return
+     */
+    public String toActionString(){
+        switch(this) {
+            case KILL: return "Killed";
+            case BLOCK_PLACE: return "Block Place";
+            case BLOCK_BREAK: return "Block Break";
+            case BUCKET_FILL: return "Bucket Fill";
+            case BUCKET_EMPTY: return "Buckety Empty";
+            case ENTRY: return "Entry";
+            case USED: case BLOCK_USED: return "Used";
+            case IGNITED: return "Ignited";
+            case BLOCK_BURN: return "Block Burn";
+            case LOGIN: return "Login";
+            case LOGOUT: return "Logout";
+            case EXCHANGE: return "Exchanged";
+            case VEHICLE_DESTROY: return "Destroyed";
+            case ENTITY_MOUNT: return "Mount";
+            case ENTITY_DISMOUNT: return "Dismount";
+            default: return "Unknown";
         }
     }
 }

--- a/src/main/java/com/untamedears/JukeAlert/model/LoggedAction.java
+++ b/src/main/java/com/untamedears/JukeAlert/model/LoggedAction.java
@@ -1,10 +1,8 @@
 package com.untamedears.JukeAlert.model;
 
-import java.util.logging.Level;
+import java.text.ParseException;
 
 import org.bukkit.ChatColor;
-
-import com.untamedears.JukeAlert.JukeAlert;
 
 /**
  * Enum that represents a type of action that a snitch can record, and the value
@@ -15,33 +13,51 @@ import com.untamedears.JukeAlert.JukeAlert;
 public enum LoggedAction {
 
     // ONCE THIS GOES INTO PRODUCTION, _NEVER_ CHANGE THESE, only mark some as not used and add more with larger values!
-    UNKNOWN(0x7FFFFFFF),
-    KILL(0),
-    BLOCK_PLACE(1),
-    BLOCK_BREAK(2),
-    BUCKET_FILL(3),
-    BUCKET_EMPTY(4),
-    ENTRY(5),
-    USED(6),
-    IGNITED(7),
-    BLOCK_BURN(8),
-    BLOCK_USED(9),
-    LOGIN(10),
-    LOGOUT(11),
-    EXCHANGE(12),
-    VEHICLE_DESTROY(13),
-    ENTITY_MOUNT(14),
-    ENTITY_DISMOUNT(15);
+    UNKNOWN(0x7FFFFFFF, "Unknown", ChatColor.WHITE, 0),
+    KILL(0, "Killed", ChatColor.DARK_RED, 3),
+    BLOCK_PLACE(1, "Block Place", ChatColor.DARK_RED, 2),
+    BLOCK_BREAK(2, "Block Break", ChatColor.DARK_RED, 2),
+    BUCKET_FILL(3, "Buket Fill", ChatColor.GREEN, 2),
+    BUCKET_EMPTY(4, "Bucket Empty", ChatColor.DARK_RED, 2),
+    ENTRY(5, "Entry", ChatColor.BLUE, 1),
+    USED(6, "Used", ChatColor.GREEN, 2),
+    IGNITED(7, "Ignited", ChatColor.GOLD, 2),
+    BLOCK_BURN(8, "Block Burn", ChatColor.DARK_RED, 2),
+    BLOCK_USED(9, "Used", ChatColor.GREEN, 2),
+    LOGIN(10, "Login", ChatColor.GREEN, 1),
+    LOGOUT(11, "Logout", ChatColor.GREEN, 1),
+    EXCHANGE(12, "Exchanged", ChatColor.DARK_GRAY, 2),
+    VEHICLE_DESTROY(13, "Destroyed", ChatColor.DARK_RED, 3),
+    ENTITY_MOUNT(14, "Mount", ChatColor.RED, 3),
+    ENTITY_DISMOUNT(15, "Dismount", ChatColor.GOLD, 3);
     
     private int value;
+    private String actionString;
+    private ChatColor actionColor;
+    private int actionTextType;
 
     // constructor, has to be private
-    private LoggedAction(int value) {
+    private LoggedAction(int value, String actionString, ChatColor actionColor, int actionTextType) {
         this.value = value;
+        this.actionString = actionString;
+        this.actionColor = actionColor;
+        this.actionTextType = actionTextType;
     }
 
     public int getLoggedActionId() {
         return this.value;
+    }
+    
+    public String getActionString(){
+        return this.actionString;
+    }
+    
+    public ChatColor getActionColor(){
+        return this.actionColor;
+    }
+    
+    public int getActionTextType(){
+        return this.actionTextType;
     }
 
     public static LoggedAction getFromId(int id) {
@@ -67,28 +83,20 @@ public enum LoggedAction {
     }
     
     /**
-     * Returns the 'human-friendly' version of the action
-     * Currently this is only used when displaying snitch logs
-     * @return
+     * Attempts to match a string to one of the LoggedAction actions
+     * @param action - string representation of the action (case insensitive). 
+     *                 Either human-friendly (e.g. "Buket Fill") or one of the enum names (e.g. "BLOCK_BURN")
+     * @return matching LoggedAction
+     * @throws ParseException if the string couldn't be decoded to a LoggedAction
      */
-    public String toActionString(){
-        switch(this) {
-            case KILL: return "Killed";
-            case BLOCK_PLACE: return "Block Place";
-            case BLOCK_BREAK: return "Block Break";
-            case BUCKET_FILL: return "Bucket Fill";
-            case BUCKET_EMPTY: return "Buckety Empty";
-            case ENTRY: return "Entry";
-            case USED: case BLOCK_USED: return "Used";
-            case IGNITED: return "Ignited";
-            case BLOCK_BURN: return "Block Burn";
-            case LOGIN: return "Login";
-            case LOGOUT: return "Logout";
-            case EXCHANGE: return "Exchanged";
-            case VEHICLE_DESTROY: return "Destroyed";
-            case ENTITY_MOUNT: return "Mount";
-            case ENTITY_DISMOUNT: return "Dismount";
-            default: return "Unknown";
+    public static LoggedAction fromString(String action) throws ParseException{        
+        for (LoggedAction a : LoggedAction.values()){
+            String actionName = a.toString();
+            String actionDisp = a.actionString;
+            if (actionName.equalsIgnoreCase(action) || actionDisp.equalsIgnoreCase(action)){
+                return a;
+            }
         }
+        throw new ParseException("Couldn't convert " + action + " to a LoggedAction", 0);
     }
 }

--- a/src/main/java/com/untamedears/JukeAlert/model/LoggedAction.java
+++ b/src/main/java/com/untamedears/JukeAlert/model/LoggedAction.java
@@ -17,7 +17,7 @@ public enum LoggedAction {
     KILL(0, "Killed", ChatColor.DARK_RED, 3),
     BLOCK_PLACE(1, "Block Place", ChatColor.DARK_RED, 2),
     BLOCK_BREAK(2, "Block Break", ChatColor.DARK_RED, 2),
-    BUCKET_FILL(3, "Buket Fill", ChatColor.GREEN, 2),
+    BUCKET_FILL(3, "Bucket Fill", ChatColor.GREEN, 2),
     BUCKET_EMPTY(4, "Bucket Empty", ChatColor.DARK_RED, 2),
     ENTRY(5, "Entry", ChatColor.BLUE, 1),
     USED(6, "Used", ChatColor.GREEN, 2),

--- a/src/main/java/com/untamedears/JukeAlert/tasks/GetSnitchInfoPlayerTask.java
+++ b/src/main/java/com/untamedears/JukeAlert/tasks/GetSnitchInfoPlayerTask.java
@@ -4,13 +4,14 @@
  */
 package com.untamedears.JukeAlert.tasks;
 
-import com.untamedears.JukeAlert.JukeAlert;
-import com.untamedears.JukeAlert.chat.SendSnitchInfo;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.entity.Player;
+
+import com.untamedears.JukeAlert.JukeAlert;
+import com.untamedears.JukeAlert.chat.SendSnitchInfo;
+import com.untamedears.JukeAlert.model.LoggedAction;
 
 /**
  *
@@ -24,6 +25,8 @@ public class GetSnitchInfoPlayerTask implements Runnable {
     private int snitchId;
     private String snitchName;
     private String group;
+    private LoggedAction filterAction;
+    private String filterPlayer;
     private final Player player;
     private final JukeAlert plugin;
 
@@ -34,27 +37,41 @@ public class GetSnitchInfoPlayerTask implements Runnable {
         this.player = player;
         this.plugin = plugin;
         this.shouldCensor = shouldCensor;
-
-    	this.group = null;
+        this.group = null;
+        this.filterAction = null;
+        this.filterPlayer = "";
     }
-
-    public GetSnitchInfoPlayerTask(JukeAlert plugin, String group,
-			int offset, Player player) {
-    	this.group = group;
+    
+    public GetSnitchInfoPlayerTask(JukeAlert plugin, int snitchId, String snitchName, int offset, Player player, boolean shouldCensor,
+            LoggedAction filterAction, String filterPlayer) {
+        this.snitchId = snitchId;
+        this.snitchName = snitchName;
         this.offset = offset;
         this.player = player;
         this.plugin = plugin;
+        this.shouldCensor = shouldCensor;
+        this.group = null;
+        this.filterAction = filterAction;
+        this.filterPlayer = filterPlayer;
+    }
 
+    public GetSnitchInfoPlayerTask(JukeAlert plugin, String group, int offset, Player player) {
+        this.group = group;
+        this.offset = offset;
+        this.player = player;
+        this.plugin = plugin;
         this.snitchId = -1;
         this.snitchName = null;
         this.shouldCensor = false;
-	}
+        this.filterAction = null;
+        this.filterPlayer = "";
+    }
 
 	@Override
     public void run() {
 		SendSnitchInfo sendSnitchInfo;
 		if (group == null)
-			sendSnitchInfo = new SendSnitchInfo(plugin.getJaLogger().getSnitchInfo(snitchId, (offset-1) * 10), this.player, offset, this.snitchName, shouldCensor, false);
+			sendSnitchInfo = new SendSnitchInfo(plugin.getJaLogger().getSnitchInfo(snitchId, (offset-1) * 10, this.filterAction, this.filterPlayer), this.player, offset, this.snitchName, shouldCensor, false);
 		else
 			sendSnitchInfo = new SendSnitchInfo(plugin.getJaLogger().getSnitchGroupInfo(group, (offset-1) * 10), this.player, offset, null, false, true);
 		sendSnitchInfo.run();

--- a/src/main/java/com/untamedears/JukeAlert/tasks/GetSnitchInfoTask.java
+++ b/src/main/java/com/untamedears/JukeAlert/tasks/GetSnitchInfoTask.java
@@ -30,7 +30,7 @@ public class GetSnitchInfoTask implements Runnable {
 
     @Override
     public void run() {
-        List<SnitchAction> entries = plugin.getJaLogger().getSnitchInfo(snitchId, offset * 10);
+        List<SnitchAction> entries = plugin.getJaLogger().getSnitchInfo(snitchId, offset * 10, null, "");
         if (entries != null && !entries.isEmpty()){
             for (SnitchAction entry : entries){
                 info.add(JukeAlertLogger.createInfoString(entry, false, false));


### PR DESCRIPTION
Closes #62 

The new /jainfo syntax looks like this:

`/jainfo [<page number> or 'next'] [censor] [action=<action type>] [player=<username>]`

Actions can be specified in LoggedAction format (KILL, BLOCK_PLACE, etc) or the format that's displayed in juke logs (Killed, Block Place, etc). Note that you will need to enclose any actions with a space in double quotes, (e.g. action="Block Place").

Arguments can be in any order and case doesn't matter. The player parameter has wildcards around it, so any substring of a username will match (e.g. player=grief will match dirtygriefer334 and GrIeFiNgNaMeS).

I've also added tab completion, and fixed the next/censor logic. It was a bit weird before.